### PR TITLE
Update registration and login view

### DIFF
--- a/app/src/main/resources/static/css/style.css
+++ b/app/src/main/resources/static/css/style.css
@@ -2,3 +2,15 @@
     width: max-content;
     margin: auto;
 }
+
+.areaButton {
+    text-align: center;
+}
+
+.areaButton button {
+    width: 72px;
+}
+
+.linkRegistration {
+    text-align: center;
+}

--- a/app/src/main/resources/static/css/style.css
+++ b/app/src/main/resources/static/css/style.css
@@ -1,5 +1,4 @@
 .areaLogin {
-    width: 500px;
-    margin-left: auto;
-    margin-right: auto;
+    width: max-content;
+    margin: auto;
 }

--- a/app/src/main/resources/static/css/style_posts.css
+++ b/app/src/main/resources/static/css/style_posts.css
@@ -68,7 +68,7 @@
     margin-bottom: 0px;
 }
 
-.areaLoginUser {
+.areaLoginUserMenu {
     display: inline-block;
     width: 400px;
     height: 400px;
@@ -76,6 +76,12 @@
 
 .ImageLoginUser {
     text-align: center;
+}
+
+.areaLoginUser {
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 .areaLoginUserProfile {

--- a/app/src/main/resources/static/css/style_registration.css
+++ b/app/src/main/resources/static/css/style_registration.css
@@ -2,3 +2,16 @@
     width: max-content;
     margin: auto;
 }
+
+.areaButtons {
+    text-align: center;
+    letter-spacing: 20px;
+}
+
+.areaButtons button {
+    width: 72px;
+}
+
+.linkLogin {
+    text-align: center;
+}

--- a/app/src/main/resources/static/css/style_registration.css
+++ b/app/src/main/resources/static/css/style_registration.css
@@ -1,0 +1,4 @@
+.areaResister {
+    width: max-content;
+    margin: auto;
+}

--- a/app/src/main/resources/static/js/posts.js
+++ b/app/src/main/resources/static/js/posts.js
@@ -13,9 +13,9 @@ window.onload = function() {
 document.getElementById("buttonMore").onclick = function () {
     var list_hidden = document.getElementsByClassName("is_hidden");
     for(var i = 0; i < moreNum; i++) {
-        if(list_hidden.length > 0) list_hidden.item(0).classList.remove("is_hidden");
+        if (list_hidden.length > 0) list_hidden.item(0).classList.remove("is_hidden");
         else break;
-    
+    }
     if (list_hidden.length == 0) {
         document.getElementById("buttonMore").remove();
     }

--- a/app/src/main/resources/static/js/registration.js
+++ b/app/src/main/resources/static/js/registration.js
@@ -1,8 +1,9 @@
 var form = document.getElementById("formRegister");
 
 document.getElementById("buttonSubmit").onclick = function () {
-    form.password.setCustomValidity("");
     if(form.password.value != form.passwordConfirm.value) {
         form.passwordConfirm.setCustomValidity("パスワードが一致しません。");
+    } else {
+        form.passwordConfirm.setCustomValidity("");
     }
 }

--- a/app/src/main/resources/static/js/registration.js
+++ b/app/src/main/resources/static/js/registration.js
@@ -1,0 +1,8 @@
+var form = document.getElementById("formRegister");
+
+document.getElementById("buttonSubmit").onclick = function () {
+    form.password.setCustomValidity("");
+    if(form.password.value != form.passwordConfirm.value) {
+        form.passwordConfirm.setCustomValidity("パスワードが一致しません。");
+    }
+}

--- a/app/src/main/resources/templates/index.html
+++ b/app/src/main/resources/templates/index.html
@@ -27,15 +27,21 @@
             <tr>
                 <td></td>
                 <td class="body">
-                    <button type="submit">ログイン</button>
+                    <div style="text-align: center">
+                        <button type="submit" style="width: 72px">ログイン</button>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td></td>
+                <td>
+                    <div style="text-align: center">
+                        <a th:href="@{/registration}">ユーザー登録ページ</a>
+                    </div>
                 </td>
             </tr>
         </table>
     </form>
-
-    <div class="link">
-        <a th:href="@{/registration}">ユーザー登録ページ</a>
-    </div>
 
 </div>
 

--- a/app/src/main/resources/templates/index.html
+++ b/app/src/main/resources/templates/index.html
@@ -27,15 +27,15 @@
             <tr>
                 <td></td>
                 <td class="body">
-                    <div style="text-align: center">
-                        <button type="submit" style="width: 72px">ログイン</button>
+                    <div class="areaButton">
+                        <button id="buttonLogin" type="submit">ログイン</button>
                     </div>
                 </td>
             </tr>
             <tr>
                 <td></td>
                 <td>
-                    <div style="text-align: center">
+                    <div class="linkRegistration">
                         <a th:href="@{/registration}">ユーザー登録ページ</a>
                     </div>
                 </td>

--- a/app/src/main/resources/templates/posts.html
+++ b/app/src/main/resources/templates/posts.html
@@ -33,11 +33,11 @@
         </div>
     </div>
 
-    <div class="areaLoginUser">
+    <div class="areaLoginUserMenu">
         <div class="ImageLoginUser">
             <img th:src="@{/image/icon.png}" width="90" height="80">
         </div>
-        <div style="display: flex; justify-content: center; align-items: center">
+        <div class="areaLoginUser">
             <div class="areaLoginUserProfile">
                 <b class="areaLoginUserName" th:text="${user.name}"></b>
                 <p class="areaLoginUserLoginId" th:text="${user.loginId}"></p>

--- a/app/src/main/resources/templates/registration.html
+++ b/app/src/main/resources/templates/registration.html
@@ -5,6 +5,7 @@
     <link th:href=@{/css/style_registration.css} rel="stylesheet" type="text/css">
     <title>Registration</title>
 </head>
+
 <body>
 
     <header class="areaHeader">ユーザ登録</header>
@@ -39,16 +40,16 @@
                 <tr>
                     <td></td>
                     <td>
-                        <div style="text-align: center; letter-spacing: 20px">
-                            <button id="buttonSubmit" type="submit" style="width: 72px">送信</button>
-                            <button type="reset" style="width: 72px">リセット</button>
+                        <div class="areaButtons">
+                            <button id="buttonSubmit" type="submit">送信</button>
+                            <button id="buttonReset" type="reset">リセット</button>
                         </div>
                     </td>
                 </tr>
                 <tr>
                     <td></td>
                     <td>
-                        <div style="text-align: center">
+                        <div class="linkLogin">
                             <a th:href="@{/}">ログインページ</a>
                         </div>
                     </td>
@@ -56,7 +57,9 @@
             </table>
         </form>
     </div>
+
 </body>
 
 <script src="js/registration.js"></script>
+
 </html>

--- a/app/src/main/resources/templates/registration.html
+++ b/app/src/main/resources/templates/registration.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
+    <link th:href=@{/css/style_registration.css} rel="stylesheet" type="text/css">
     <title>Registration</title>
 </head>
 <body>
@@ -9,35 +10,53 @@
     <header class="areaHeader">ユーザ登録</header>
 
     <div class="areaResister">
-        <form th:action="@{/registration}" th:method="post">
-            <table border="1" class="areaResisterTable">
+        <form id="formRegister" th:action="@{/registration}" th:method="post">
+            <table border="0" class="areaResisterTable">
                 <tr>
                     <td class="head">名前</td>
                     <td class="body">
-                        <input type="text" name="name" size="50">
+                        <input type="text" name="name" size="32">
                     </td>
                 </tr>
                 <tr>
                     <td class="head">ID</td>
                     <td class="body">
-                        <input type="text" name="loginId" size="16">
+                        <input type="text" name="loginId" size="32">
                     </td>
                 </tr>
                 <tr>
                     <td class="head">パスワード</td>
                     <td class="body">
-                        <input type="text" name="password" size="64">
+                        <input type="password" name="password" size="32">
                     </td>
                 </tr>
                 <tr>
-                    <td colspan="2">
-                        <button type="submit">送信</button>
-                        <button type="reset">リセット</button>
+                    <td class="head">パスワード(確認用)</td>
+                    <td class="body">
+                        <input type="password" name="passwordConfirm" size="32">
+                    </td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td>
+                        <div style="text-align: center; letter-spacing: 20px">
+                            <button id="buttonSubmit" type="submit" style="width: 72px">送信</button>
+                            <button type="reset" style="width: 72px">リセット</button>
+                        </div>
+                    </td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td>
+                        <div style="text-align: center">
+                            <a th:href="@{/}">ログインページ</a>
+                        </div>
                     </td>
                 </tr>
             </table>
         </form>
     </div>
-
 </body>
+
+<script src="js/registration.js"></script>
 </html>


### PR DESCRIPTION
## 内容 
- ユーザ登録ページの修正
   - 全体の配置を変更
   - パスワード確認用フォームの追加
   - ログインページへのリンクを追加
- ログインページの修正
   - 全体の配置を変更 

## テスト

## 差分
Before
<img width="381" alt="スクリーンショット 2021-04-09 13 51 34" src="https://user-images.githubusercontent.com/51780741/114130227-0de28000-993b-11eb-8c42-bd8e9efc8d5b.png">
<img width="587" alt="スクリーンショット 2021-04-09 13 51 42" src="https://user-images.githubusercontent.com/51780741/114130242-163abb00-993b-11eb-9e17-67f042291c0c.png">
After
<img width="408" alt="スクリーンショット 2021-04-09 13 50 49" src="https://user-images.githubusercontent.com/51780741/114130260-1e92f600-993b-11eb-8382-f51b07d11ba4.png">
<img width="442" alt="スクリーンショット 2021-04-09 13 50 55" src="https://user-images.githubusercontent.com/51780741/114130266-218de680-993b-11eb-8dde-06cedeff5a87.png">

## 残項目

## その他