### PR TITLE
Fix area post comment

### DIFF
--- a/app/src/main/resources/static/css/style_posts.css
+++ b/app/src/main/resources/static/css/style_posts.css
@@ -37,6 +37,8 @@
 .areaPostDetail {
     width: 320px;
     height: 100px;
+    overflow: auto;
+    overflow-wrap: break-word;
     border: solid;
     border-radius: 8px;
     margin-top: 0px;


### PR DESCRIPTION
## 内容 
- 投稿内容の表示方法を修正
   - 枠内に収まらない長さの投稿: 枠からはみ出して表示 -> スクロールで枠に収まるように表示
   - 一行に収まらない長さの単語を含む投稿: 枠からはみ出して表示 -> 一行に治らない単語のみ単語の途中で改行して表示

## テスト
- 枠内に収まらない長さの投稿
- 一行に収まらない長さの単語(スペースを含まない半角英数字の文字列)を含む投稿

## 差分
Before
<img width="466" alt="スクリーンショット 2021-04-09 13 44 33" src="https://user-images.githubusercontent.com/51780741/114129761-3158fb00-993a-11eb-9607-81e0af750073.png">
After
<img width="442" alt="スクリーンショット 2021-04-09 13 45 08" src="https://user-images.githubusercontent.com/51780741/114129682-04a4e380-993a-11eb-99a2-4f9163068d7e.png">

## 残項目

## その他