### PR TITLE
Update details

### DIFF
--- a/app/src/main/kotlin/com/task/sns/sns/domain/entity/Post.kt
+++ b/app/src/main/kotlin/com/task/sns/sns/domain/entity/Post.kt
@@ -17,10 +17,6 @@ data class Post(
     @ManyToOne
     var user: User,
 
-//    @field:NotNull
-//    @Column(name = "user_id", columnDefinition = "INT UNSIGNED")
-//    var userId: Int = 0,
-
     @field:NotBlank
     @Column(columnDefinition = "VARCHAR(140)", nullable = false)
     var comment: String = "",

--- a/app/src/main/resources/static/css/style_posts.css
+++ b/app/src/main/resources/static/css/style_posts.css
@@ -30,12 +30,12 @@
 .areaPostComment {
     display: inline-block;
     vertical-align: top;
-    width: 400px;
+    width: 360px;
     height: 150px;
 }
 
 .areaPostDetail {
-    width: 400px;
+    width: auto;
     height: 100px;
     overflow: auto;
     overflow-wrap: break-word;
@@ -46,7 +46,6 @@
 }
 
 .areaPostInformation {
-    /*position: relative;*/
     text-align: left;
     width: auto;
     height: 40px;

--- a/app/src/main/resources/templates/index.html
+++ b/app/src/main/resources/templates/index.html
@@ -7,7 +7,9 @@
 </head>
 <body>
 
-<h3 class="areaHeader">ログイン</h3>
+<header class="areaHeader">
+    <h3>ログイン</h3>
+</header>
 
 <div class="areaLogin">
     <form th:action="@{/login}" th:method="post">

--- a/app/src/main/resources/templates/index.html
+++ b/app/src/main/resources/templates/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
 
-<header class="areaHeader">ログイン</header>
+<h3 class="areaHeader">ログイン</h3>
 
 <div class="areaLogin">
     <form th:action="@{/login}" th:method="post">

--- a/app/src/main/resources/templates/posts.html
+++ b/app/src/main/resources/templates/posts.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 
-    <header class="areaHeader">SNSApp</header>
+    <h3 class="areaHeader">SNSApp</h3>
 
     <div class="areaPosts">
         <div class="areaPost" th:each="post:${posts}" th:object="${post}">
@@ -23,7 +23,7 @@
             <div class="areaPostComment">
                 <p class="areaPostDetail" th:text="*{comment}"></p>
                 <div class="areaPostInformation">
-                    <p class="areaPostCreateAt" th:text="*{createAt}"></p>
+                    <p class="areaPostCreateAt" th:text="${#dates.format(post.createAt, 'yyyy/MM/dd HH:mm:ss')}"></p>
                     <p class="areaPostLikeCount" th:if="${count.get(post.postId)!=null}" th:text="'いいね: ' + ${count.get(post.postId)}"></p>
                     <p class="areaPostLikeCount" th:if="${count.get(post.postId)==null}" th:text="'いいね: 0'"></p>
                     <form id="formPostLike" th:action="@{/post}">

--- a/app/src/main/resources/templates/posts.html
+++ b/app/src/main/resources/templates/posts.html
@@ -9,7 +9,9 @@
 </head>
 <body>
 
-    <h3 class="areaHeader">SNSApp</h3>
+    <header class="areaHeader">
+        <h3>SNSApp</h3>
+    </header>
 
     <div class="areaPosts">
         <div class="areaPost" th:each="post:${posts}" th:object="${post}">

--- a/app/src/main/resources/templates/registration.html
+++ b/app/src/main/resources/templates/registration.html
@@ -8,13 +8,13 @@
 
 <body>
 
-    <header class="areaHeader">ユーザ登録</header>
+    <h3 class="areaHeader">ユーザ登録</h3>
 
     <div class="areaResister">
         <form id="formRegister" th:action="@{/registration}" th:method="post">
             <table border="0" class="areaResisterTable">
                 <tr>
-                    <td class="head">名前</td>
+                    <td class="head">NAME</td>
                     <td class="body">
                         <input type="text" name="name" size="32">
                     </td>
@@ -26,13 +26,13 @@
                     </td>
                 </tr>
                 <tr>
-                    <td class="head">パスワード</td>
+                    <td class="head">PASSWORD</td>
                     <td class="body">
                         <input type="password" name="password" size="32">
                     </td>
                 </tr>
                 <tr>
-                    <td class="head">パスワード(確認用)</td>
+                    <td class="head">PASSWORD(確認)</td>
                     <td class="body">
                         <input type="password" name="passwordConfirm" size="32">
                     </td>

--- a/app/src/main/resources/templates/registration.html
+++ b/app/src/main/resources/templates/registration.html
@@ -8,7 +8,9 @@
 
 <body>
 
-    <h3 class="areaHeader">ユーザ登録</h3>
+    <header class="areaHeader">
+        <h3>ユーザ登録</h3>
+    </header>
 
     <div class="areaResister">
         <form id="formRegister" th:action="@{/registration}" th:method="post">


### PR DESCRIPTION
## 内容 
- 時計の表記を修正
- ログインページとユーザ登録ページの表記揺れを修正
- タイトルのサイズを変更


## テスト

## 差分
Before
<img width="442" alt="スクリーンショット 2021-04-09 13 45 08" src="https://user-images.githubusercontent.com/51780741/114824863-6b297600-9e00-11eb-8eb1-12229e58a319.png">
<img width="410" alt="スクリーンショット 2021-04-15 15 38 27" src="https://user-images.githubusercontent.com/51780741/114825038-aa57c700-9e00-11eb-8444-34c72570110d.png">

After
<img width="1060" alt="スクリーンショット 2021-04-15 15 31 14" src="https://user-images.githubusercontent.com/51780741/114824912-7c728280-9e00-11eb-97de-e7db490eaf0f.png">
<img width="424" alt="スクリーンショット 2021-04-15 15 31 23" src="https://user-images.githubusercontent.com/51780741/114825073-b5125c00-9e00-11eb-8b66-0d40e7a486d4.png">



## 残項目

## その他